### PR TITLE
avoid interface conversion error with blank struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -131,6 +131,12 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 			finalVal = val.Interface()
 		}
 
+		// if there are only omited zero values in sub struct
+		// skip to avoid interface conversion panic
+		if isSubStruct && New(val).IsZero() {
+			continue
+		}
+
 		if tagOpts.Has("string") {
 			s, ok := val.Interface().(fmt.Stringer)
 			if ok {


### PR DESCRIPTION
fix to:

panic: interface conversion: interface {} is ___, not map[string]interface {}

goroutine 84 [running]:
github.com/fatih/structs.(*Struct).FillMap(0xc4202f2f40, 0xc422385740)
	/home/khaynes/go/src/github.com/fatih/structs/structs.go:143 +0x875
github.com/fatih/structs.(*Struct).Map(0xc4202f2f40, 0xc4202de240)
	/home/khaynes/go/src/github.com/fatih/structs/structs.go:83 +0x3e
github.com/fatih/structs.Map(0x99ed20, 0xc4202de240, 0x99ed20)
	/home/khaynes/go/src/github.com/fatih/structs/structs.go:446 +0x43